### PR TITLE
make ti start/stop without time-argument work again

### DIFF
--- a/tests/dateutils/test_dateutils.py
+++ b/tests/dateutils/test_dateutils.py
@@ -52,6 +52,16 @@ class TestDateutils(TestCase):
         self.assertEqual(20, time_parsed.hour)
         self.assertEqual(15, time_parsed.minute)
 
+    @mock.patch('ti.dateutils.dateutils.get_now')
+    def test_parse_time_multiformat_with_now_string(self, mocked_datetime_now):
+        mocked_datetime_now.return_value = datetime(2019, 3, 16, 20, 15)
+        time_parsed = parse_time_multiformat("now")
+        self.assertEqual(2019, time_parsed.year)
+        self.assertEqual(3, time_parsed.month)
+        self.assertEqual(16, time_parsed.day)
+        self.assertEqual(20, time_parsed.hour)
+        self.assertEqual(15, time_parsed.minute)
+
     def test_parse_time_multiformat_not_separated(self):
         self.assertRaises(TIError, parse_time_multiformat, "51n3p")
 

--- a/ti-dev.py
+++ b/ti-dev.py
@@ -47,17 +47,22 @@ def parse_args(argv=sys.argv):
         args = {}
 
     elif head in ['start']:
-        if not tail or len(tail) != 2:
+        datestring = ' '.join(tail[1:])
+        if tail and len(tail) == 1:
+            datestring = "now"
+        elif not tail or len(tail) != 2:
             raise BadArguments("Please provide a name for the activity and the start time, like so:\n$ ti start project 14:15")
 
         fn = start.action_start
         args = {
             'colorizer': colorizer,
             'name': tail[0],
-            'time': to_datetime(' '.join(tail[1:])),
+            'time': to_datetime(datestring),
         }
 
     elif head in ['stop']:
+        if not tail or len(tail) == 0:
+            tail = ["now"]
         fn = stop.action_stop
         args = {'colorizer': colorizer, 'time': to_datetime(' '.join(tail))}
 

--- a/ti/dateutils/dateutils.py
+++ b/ti/dateutils/dateutils.py
@@ -12,6 +12,11 @@ TI_TODAY_ENV_VAR = "TI_CURRENT_DAY"
 def get_local_timezone():
     return get_localzone()
 
+
+def get_now():
+    return datetime.now()
+
+
 #   returns a datetime
 def utc_to_local(utc_dt):
     local_tz = get_local_timezone()
@@ -38,7 +43,7 @@ def local_to_utc(local_dt):
 
 
 def formatted_str_for_isotime_str(isotime_str, format_str):
-    localtime = isotime_utc_to_local(isotime_str);
+    localtime = isotime_utc_to_local(isotime_str)
     return localtime.strftime(format_str)
 
 
@@ -47,6 +52,8 @@ def get_current_day():
     return today_value
 
 def parse_time_multiformat(timestr):
+    if timestr == "now":
+        return get_now()
     for time_format in ["%H:%M", "%H%M"]:
         try:
             settime = datetime.strptime(timestr, time_format)


### PR DESCRIPTION
The readme shows the minimum usage example as:
```
$ ti start my-project
$ ti stop
```
but ti expects an explicit absolute date at the end.

With this PR ti would now use the current time as a default if no absolute date is provided for the start or stop action.